### PR TITLE
Add support for mysql databases 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ ENV/
 /site
 
 # End of https://www.gitignore.io/api/python
+
+#Pycharm
+.idea

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -37,3 +37,4 @@ tornado==4.5.1
 twine==1.8.1
 urllib3==1.21.1
 watchdog==0.8.3
+mysqlclient==1.3.12

--- a/tests/test_tornado_sqlalchemy.py
+++ b/tests/test_tornado_sqlalchemy.py
@@ -45,6 +45,11 @@ class FactoryTestCase(TestCase):
 
         self.assertTrue(factory)
 
+    def test_make_postgres_factory(self):
+        postgres_url = 'postgres://postgres:@localhost/tornado_sqlalchemy'
+        factory = make_session_factory(postgres_url)
+
+        self.assertTrue(factory)
 
 class SessionFactoryTestCase(BaseTestCase):
     def test_make_session(self):

--- a/tests/test_tornado_sqlalchemy.py
+++ b/tests/test_tornado_sqlalchemy.py
@@ -13,9 +13,7 @@ from tornado.gen import coroutine
 from tornado.web import Application, RequestHandler
 from tornado.testing import AsyncHTTPTestCase
 
-
 database_url = 'postgres://postgres:@localhost/tornado_sqlalchemy'
-
 
 Base = declarative_base()
 
@@ -40,13 +38,20 @@ class BaseTestCase(TestCase):
         Base.metadata.drop_all(self.factory.engine)
 
 
+class FactoryTestCase(TestCase):
+    def test_make_mysql_factoy(self):
+        mysql_url = 'mysql://mysql_user:mysql_pass@localhost/tornado_sqlalchemy'
+        factory = make_session_factory(mysql_url)
+
+        self.assertTrue(factory)
+
+
 class SessionFactoryTestCase(BaseTestCase):
     def test_make_session(self):
         session = self.factory.make_session()
 
         self.assertTrue(session)
         self.assertEqual(session.query(User).count(), 0)
-
         session.close()
 
 

--- a/tests/test_tornado_sqlalchemy.py
+++ b/tests/test_tornado_sqlalchemy.py
@@ -14,6 +14,7 @@ from tornado.web import Application, RequestHandler
 from tornado.testing import AsyncHTTPTestCase
 
 database_url = 'postgres://postgres:@localhost/tornado_sqlalchemy'
+mysql_url = 'mysql://mysql_user:mysql_pass@localhost/tornado_sqlalchemy'
 
 Base = declarative_base()
 
@@ -40,16 +41,15 @@ class BaseTestCase(TestCase):
 
 class FactoryTestCase(TestCase):
     def test_make_mysql_factoy(self):
-        mysql_url = 'mysql://mysql_user:mysql_pass@localhost/tornado_sqlalchemy'
         factory = make_session_factory(mysql_url)
 
         self.assertTrue(factory)
 
     def test_make_postgres_factory(self):
-        postgres_url = 'postgres://postgres:@localhost/tornado_sqlalchemy'
-        factory = make_session_factory(postgres_url)
+        factory = make_session_factory(database_url)
 
         self.assertTrue(factory)
+
 
 class SessionFactoryTestCase(BaseTestCase):
     def test_make_session(self):

--- a/tornado_sqlalchemy/__init__.py
+++ b/tornado_sqlalchemy/__init__.py
@@ -7,7 +7,6 @@ from sqlalchemy.ext.declarative import declarative_base as _declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.engine.url import make_url
 
-
 __all__ = ['SessionMixin', 'set_max_workers', 'as_future',
            'make_session_factory', 'declarative_base']
 
@@ -75,7 +74,7 @@ class SessionFactory(object):
     def _setup(self):
         kwargs = {}
         if self._database_url.get_driver_name() == 'postgresql':
-            kwargs['use_native_unicode']: self._use_native_unicode
+            kwargs['use_native_unicode'] = self._use_native_unicode
 
         if self._pool_size is not None:
             kwargs['pool_size'] = self._pool_size

--- a/tornado_sqlalchemy/__init__.py
+++ b/tornado_sqlalchemy/__init__.py
@@ -5,6 +5,7 @@ import multiprocessing
 from sqlalchemy import create_engine, event
 from sqlalchemy.ext.declarative import declarative_base as _declarative_base
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.engine.url import make_url
 
 
 __all__ = ['SessionMixin', 'set_max_workers', 'as_future',
@@ -60,7 +61,7 @@ class SessionFactory(object):
 
     def __init__(self, database_url, pool_size=None, use_native_unicode=True,
                  engine_events=None, session_events=None):
-        self._database_url = database_url
+        self._database_url = make_url(database_url)
         self._pool_size = pool_size
         self._engine_events = engine_events
         self._session_events = session_events
@@ -72,9 +73,9 @@ class SessionFactory(object):
         self._setup()
 
     def _setup(self):
-        kwargs = {
-            'use_native_unicode': self._use_native_unicode
-        }
+        kwargs = {}
+        if self._database_url.get_driver_name() == 'postgresql':
+            kwargs['use_native_unicode']: self._use_native_unicode
 
         if self._pool_size is not None:
             kwargs['pool_size'] = self._pool_size


### PR DESCRIPTION
Only provide use_native_unicode argument to engine for postgres databases, as this option is not supported by other databases. 